### PR TITLE
Minor grammatical error

### DIFF
--- a/ModDocs/draconicevolution/2.3.0/en_us/generator_cc462.md
+++ b/ModDocs/draconicevolution/2.3.0/en_us/generator_cc462.md
@@ -4,7 +4,7 @@
 §stack[draconicevolution:generator]{size:64}
 
 §rule{colour:0x606060,height:3,width:100%,top_pad:0}
-This is just a simple no thrills generator that burns most fuel sources and produces 84RF/t
+This is just a simple no frills generator that burns most fuel sources and produces 84RF/t
 
 §rule{colour:0x606060,height:3,width:100%,top_pad:0}
 §recipe[draconicevolution:generator]{spacing:2}

--- a/ModDocs/draconicevolution/2.3.20/en_us/generator_cc462.md
+++ b/ModDocs/draconicevolution/2.3.20/en_us/generator_cc462.md
@@ -4,7 +4,7 @@
 §stack[draconicevolution:generator]{size:64}
 
 §rule{colour:0x606060,height:3,width:100%,top_pad:0}
-This is just a simple no thrills generator that burns most fuel sources and produces 84RF/t
+This is just a simple no frills generator that burns most fuel sources and produces 84RF/t
 
 §rule{colour:0x606060,height:3,width:100%,top_pad:0}
 §recipe[draconicevolution:generator]{spacing:2}


### PR DESCRIPTION
Simply changed "no thrills" to "no frills" on the generator description.